### PR TITLE
Removed broken monana link

### DIFF
--- a/toc
+++ b/toc
@@ -48,7 +48,6 @@ Liberty for Java
 
     buildpackDefaults.md
     [Managing Liberty and Node.js apps](../../manageapps/app_mng.html)
-    [Getting started with IBM Monitoring and Analytics for Bluemix Service](../../services/monana/index.html#monana_oview)
     {: .navgroup-end}
 
     {: .navgroup id="help"}


### PR DESCRIPTION
Broken link to disabled content was reported via slack, so the link was removed from our TOC until the content owner returns from vacation and can provide new url.